### PR TITLE
remove url parameters from asset link (fix #3)

### DIFF
--- a/lib/jekyll/subresource-integrity-hook.rb
+++ b/lib/jekyll/subresource-integrity-hook.rb
@@ -39,6 +39,7 @@ module Jekyll
       updated = false
       doc.css('script[src], link[rel="stylesheet"]').each do |tag|
         path = tag['src'] || tag['href']
+        path.slice!(/\?.+/)
         next unless path
 
         # Compute absolute path to asset


### PR DESCRIPTION
Note: I can imagine there are edge cases where this would break something, but I _think_ locally this should be safe because `?` in URL will start the parameter part anyway? 

However, when adding external resource support (#1), the file returned can differ based on the parameters, so this action should not happen on those urls.