### PR TITLE
only log info once per source (fix #4)

### DIFF
--- a/lib/jekyll/subresource-integrity-hook.rb
+++ b/lib/jekyll/subresource-integrity-hook.rb
@@ -50,14 +50,14 @@ module Jekyll
         tag['integrity'] = integrity
         tag['crossorigin'] ||= 'anonymous'
         updated = true
-
-        Jekyll.logger.info "Generated subresource integrity hash for: #{absolute_path_source}"
       end
 
       # Write updated HTML if changes were made
       if updated
         File.write(absolute_path_source, doc.to_html)
       end
+
+      Jekyll.logger.info "Generated subresource integrity hash for: #{absolute_path_source}"
     end
 
     Jekyll::Hooks.register :site, :post_write do |site|


### PR DESCRIPTION
This is definitely my personal preferences. 

I can imagine keeping this line in place and changing `absolute_path_source` to `absolute_path_asset` would also make the log fitting. 

It is probably even better to set up a configurable verbosity.